### PR TITLE
Remove LOWER() and add missing indexes

### DIFF
--- a/db.sql
+++ b/db.sql
@@ -34,7 +34,9 @@ CREATE TABLE `user_video` (
   `playCount` int(11) NOT NULL DEFAULT 1,
   `hideFromList` tinyint(1) NOT NULL DEFAULT 0,
   PRIMARY KEY (`uservideoId`),
-  UNIQUE KEY `uservideoId_UNIQUE` (`uservideoId`)
+  UNIQUE KEY `uservideoId_UNIQUE` (`uservideoId`),
+  INDEX `idx_userId` (`userId`),
+  INDEX `idx_userId_videoId` (`userId`, `videoId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 CREATE TABLE `video` (

--- a/services/activity.js
+++ b/services/activity.js
@@ -12,7 +12,7 @@ async function getRecent(page = 1) {
             uv.lastPlayedTimestamp
      FROM user_video uv
      INNER JOIN user u ON uv.userId = u.userId
-     LEFT JOIN aliases a ON LOWER(u.nickname) = LOWER(a.aliasNick)
+     LEFT JOIN aliases a ON u.nickname = a.aliasNick
      INNER JOIN video v ON uv.videoId = v.videoId
      WHERE uv.hideFromList = 0
      ORDER BY uv.lastPlayedTimestamp DESC LIMIT ?,?`,

--- a/services/leaderboard.js
+++ b/services/leaderboard.js
@@ -6,7 +6,7 @@ const sql = `SELECT COALESCE(a.primaryNick, u.nickname) AS nickname,
   COUNT(DISTINCT uv.videoId) AS video_count
   FROM user_video uv
   INNER JOIN user u ON uv.userId = u.userId
-  LEFT JOIN aliases a ON LOWER(u.nickname) = LOWER(a.aliasNick)
+  LEFT JOIN aliases a ON u.nickname = a.aliasNick
   GROUP BY COALESCE(a.primaryNick, u.nickname)
   ORDER BY video_count DESC LIMIT ?,?`;
 

--- a/services/peepee.js
+++ b/services/peepee.js
@@ -9,7 +9,7 @@ async function getRankings(page = 1) {
             SUM(uv.playCount) AS pp_score
      FROM user_video uv
      INNER JOIN user u ON uv.userId = u.userId
-     LEFT JOIN aliases a ON LOWER(u.nickname) = LOWER(a.aliasNick)
+     LEFT JOIN aliases a ON u.nickname = a.aliasNick
      WHERE uv.hideFromList = 0
      GROUP BY COALESCE(a.primaryNick, u.nickname)
      ORDER BY pp_score DESC LIMIT ?,?`,

--- a/services/userStats.js
+++ b/services/userStats.js
@@ -9,16 +9,16 @@ async function getStats(nickname) {
             MIN(uv.lastPlayedTimestamp) AS firstShared,
             MAX(uv.lastPlayedTimestamp) AS mostRecentPlayed
      FROM user u
-     LEFT JOIN aliases a ON LOWER(u.nickname) = LOWER(a.aliasNick)
+     LEFT JOIN aliases a ON u.nickname = a.aliasNick
      INNER JOIN user_video uv ON u.userId = uv.userId
      WHERE uv.hideFromList = 0
        AND COALESCE(a.primaryNick, u.nickname) = (
          SELECT COALESCE(a2.primaryNick, u2.nickname)
          FROM user u2
-         LEFT JOIN aliases a2 ON LOWER(u2.nickname) = LOWER(a2.aliasNick)
-         WHERE LOWER(u2.nickname) = LOWER(?)
-            OR LOWER(a2.aliasNick) = LOWER(?)
-            OR LOWER(a2.primaryNick) = LOWER(?)
+         LEFT JOIN aliases a2 ON u2.nickname = a2.aliasNick
+         WHERE u2.nickname = ?
+            OR a2.aliasNick = ?
+            OR a2.primaryNick = ?
          LIMIT 1
        )
      GROUP BY COALESCE(a.primaryNick, u.nickname)`,

--- a/services/users.js
+++ b/services/users.js
@@ -40,10 +40,10 @@ async function getByNickname(nickname){
   const rows = await db.query(
     `SELECT u.userId, COALESCE(a.primaryNick, u.nickname) AS nickname
     FROM user u
-    LEFT JOIN aliases a ON LOWER(u.nickname) = LOWER(a.aliasNick)
-    WHERE LOWER(u.nickname) = LOWER(?)
-       OR LOWER(a.aliasNick) = LOWER(?)
-       OR LOWER(a.primaryNick) = LOWER(?)
+    LEFT JOIN aliases a ON u.nickname = a.aliasNick
+    WHERE u.nickname = ?
+       OR a.aliasNick = ?
+       OR a.primaryNick = ?
     LIMIT 1`,
     [nickname, nickname, nickname]
   );

--- a/services/videos.js
+++ b/services/videos.js
@@ -11,10 +11,10 @@ async function getMultiple(userid, page = 1){
     WHERE uv.hideFromList = 0 AND uv.userId IN (
       SELECT u.userId FROM user u
       WHERE COALESCE(
-        (SELECT primaryNick FROM aliases WHERE LOWER(aliasNick) = LOWER(u.nickname) LIMIT 1),
+        (SELECT primaryNick FROM aliases WHERE aliasNick = u.nickname LIMIT 1),
         u.nickname
       ) = COALESCE(
-        (SELECT primaryNick FROM aliases WHERE LOWER(aliasNick) = (SELECT LOWER(nickname) FROM user WHERE userId = ?) LIMIT 1),
+        (SELECT primaryNick FROM aliases WHERE aliasNick = (SELECT nickname FROM user WHERE userId = ?) LIMIT 1),
         (SELECT nickname FROM user WHERE userId = ?)
       )
     )
@@ -26,10 +26,10 @@ async function getMultiple(userid, page = 1){
     WHERE hideFromList = 0 AND userId IN (
       SELECT u.userId FROM user u
       WHERE COALESCE(
-        (SELECT primaryNick FROM aliases WHERE LOWER(aliasNick) = LOWER(u.nickname) LIMIT 1),
+        (SELECT primaryNick FROM aliases WHERE aliasNick = u.nickname LIMIT 1),
         u.nickname
       ) = COALESCE(
-        (SELECT primaryNick FROM aliases WHERE LOWER(aliasNick) = (SELECT LOWER(nickname) FROM user WHERE userId = ?) LIMIT 1),
+        (SELECT primaryNick FROM aliases WHERE aliasNick = (SELECT nickname FROM user WHERE userId = ?) LIMIT 1),
         (SELECT nickname FROM user WHERE userId = ?)
       )
     )`,


### PR DESCRIPTION
Since all tables are using utf8mb4_unicode_520_ci collation
LOWER() should not be necessary, LOWER() usually prevents index usage.

Also adding missing indexes to the user_video table:

```
ALTER TABLE `user_video`
    ADD INDEX `idx_userId` (`userId`),
    ADD INDEX `idx_userId_videoId` (`userId`, `videoId`);
```

I wonder if this will give us slightly faster loading times.